### PR TITLE
fix dir-AP bold scans that were mislabelled as PA

### DIFF
--- a/heuristics/trident_15T.py
+++ b/heuristics/trident_15T.py
@@ -279,7 +279,7 @@ def infotodict(seqinfo):
 
         # Resting-state
         elif "rsfMRI" in s.series_description:
-            if "RPE" in s.series_description:
+            if "RPE" in s.series_description or "RV" in s.series_description:
                 info[func_resting_RV].append(s.series_id)
             else:
                 info[func_resting_R].append(s.series_id)


### PR DESCRIPTION
affects lecanemab_early and lecanemab_late bids datasets. local datasets already updated now with this, so merging it in..