### PR TITLE
trip-ki-char: update session handling, split off pilot subj

### DIFF
--- a/config/trident/trip-ki-char.yml
+++ b/config/trident/trip-ki-char.yml
@@ -33,6 +33,7 @@ study_filter_specs:
     - "subject.str.contains('145M')"
     - "subject.str.contains('135M')"
     - "subject.str.contains('148M')"
+    - StudyInstanceUID == '2.16.756.5.5.200.8323328.3429.1752152862.8' #exclude 159BM4 20250710 scan (was re-done the day after)
 
 
   remap_sessions_by_date:
@@ -71,7 +72,18 @@ study_filter_specs:
       3: '9m'
       6: '12m'
       10: '16m'
- 
+
+  remap_values:
+    - query: "subject.str.startswith('05F') and StudyDate == 20251030"
+      column: session
+      value: '9m'
+    - query: "subject.str.startswith('05F') and StudyDate == 20260128"
+      column: session
+      value: '12m'
+    - query: "subject.str.startswith('05F') and StudyDate == 20260601"
+      column: session
+      value: '16m'
+
 # 3. download
 cfmm2tar_download_options: '--skip-derived'
 merge_duplicate_studies: False  

--- a/config/trident/trip-ki-char_pilot.yml
+++ b/config/trident/trip-ki-char_pilot.yml
@@ -1,6 +1,6 @@
 # general 
 credentials_file: ~/.uwo_credentials.bd
-final_bids_dir: "/nfs/trident3/mri/schmitz/trip-ki-char/bids"
+final_bids_dir: "/nfs/trident3/mri/schmitz/trip-ki-char_pilot/bids"
 
 # 1. query
 search_specs:
@@ -28,12 +28,8 @@ query_kwargs:
 # 2. filter
 study_filter_specs:
   include:
+    - "subject.str.startswith('145M') or subject.str.startswith('135M') or subject.str.startswith('148M')"
   exclude:
-    - "subject != subject"                  # Exclude if subject is NaN
-    - "subject.str.contains('145M')"
-    - "subject.str.contains('135M')"
-    - "subject.str.contains('148M')"
-
 
   remap_sessions_by_date:
     # Enable/disable session remapping (REQUIRED if section is present)
@@ -48,9 +44,8 @@ study_filter_specs:
     # Can also be a list for unequally-spaced timepoints, e.g. round_step: [0, 3, 6, 10]
     round_step: 
       - 0
-      - 3
-      - 6
-      - 10
+      - 2
+      - 4
     
     # Zero-pad session labels (OPTIONAL, default: false)
     # If true, pads session labels with leading zeros for proper alphanumeric sorting
@@ -67,10 +62,9 @@ study_filter_specs:
     # If not specified, generates labels like '0m', '6m', '12m' automatically
     # Custom mapping example (e.g., for time since baseline):
     time_to_label:
-      0: '6m'
-      3: '9m'
-      6: '12m'
-      10: '16m'
+      0: '2m'
+      2: '4m'
+      4: '6m'
  
 # 3. download
 cfmm2tar_download_options: '--skip-derived'
@@ -100,11 +94,11 @@ post_convert_fixes:
 
 #intermediate output folders
 stages:
-  query: "results/trip-ki-char/0_query"
-  filter: "results/trip-ki-char/1_filter"
-  download: "results/trip-ki-char/2_download"
-  convert: "results/trip-ki-char/3_convert"
-  fix: "results/trip-ki-char/4_fix"
+  query: "results/trip-ki-char_pilot/0_query"
+  filter: "results/trip-ki-char_pilot/1_filter"
+  download: "results/trip-ki-char_pilot/2_download"
+  convert: "results/trip-ki-char_pilot/3_convert"
+  fix: "results/trip-ki-char_pilot/4_fix"
 
  
 # Centralized download cache 


### PR DESCRIPTION
fixes #106.

Also splits off the pilot subjects (that have 2m,4m,6m sessions)

uses new round_step list feature from #107 

