### PR TITLE
Update gradcorrect to latest version to fix casting bug

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -578,7 +578,7 @@ rule gradcorrect:
         mem_mb=40000,
         runtime=240,
     container:
-        "docker://khanlab/gradcorrect:v0.0.3a"
+        "docker://khanlab/gradcorrect:v0.1.0"
     shadow:
         "minimal"
     shell:


### PR DESCRIPTION
This pull request updates the `gradcorrect` rule in the `workflow/Snakefile` to use a newer version of the `khanlab/gradcorrect` container. This fixes the casting bug (ushort - sshort) that affected dwi and bold data. 

- Dependency update:
  * Updated the `gradcorrect` rule to use the `khanlab/gradcorrect:v0.1.0` container instead of `v0.0.3a`.