### PR TITLE
Update HC remapping and improve workflow

### DIFF
--- a/config/snsx/config_snsx_hc.yml
+++ b/config/snsx/config_snsx_hc.yml
@@ -47,6 +47,7 @@ search_specs:
           C03: C003
           C41: C041
           C50: C050
+          C75: C075
           
         pattern: '[sS][nN][sS][xX]_([cCpP][0-9]+)$'
         sanitize: true

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -292,7 +292,7 @@ rule cfmm2tar_by_uid:
     threads: 1
     resources:
         mem_mb=4000,
-        runtime=15,
+        runtime=60,
     shell:
         "cfmm2tar -c {params.creds_file} {params.cfmm2tar_download_options} {params.uid} {output.dicoms_dir} &> {log}"
 
@@ -495,7 +495,6 @@ rule post_convert_fix:
     """
     input:
         bids_subj_dir=stage_convert / "bids-staging/sub-{subject}/ses-{session}",
-        validator_json=stage_convert / "qc/bids_validator.json",
     output:
         bids_subj_dir=directory(stage_fix / "bids-staging/sub-{subject}/ses-{session}"),
         prov_json=stage_fix


### PR DESCRIPTION
This pull request introduces several updates to the workflow configuration and search specifications. The most significant changes involve increasing the runtime allocation for a key workflow rule, updating search patterns, and modifying the input requirements for a post-conversion fix rule.

**Workflow configuration changes:**

* Increased the `runtime` resource limit for the `cfmm2tar_by_uid` rule from 15 to 60 minutes in `workflow/Snakefile` to allow more time for processing.
* Removed the `validator_json` input from the `post_convert_fix` rule in `workflow/Snakefile`, simplifying its input requirements.

**Search specification updates:*

* remap C75 to C075 (operator error)